### PR TITLE
feature/PN-2177

### DIFF
--- a/scripts/global-redirect/README.md
+++ b/scripts/global-redirect/README.md
@@ -1,0 +1,40 @@
+Passi per la gestione della redirect da notifichedigitali.it a www.notifichedigitali.it
+
+__N.B.__: da definire in che Account AWS avverrà il deploy della soluzione.
+
+# Generazione certificato
+- Generare con la console ACM (Amazon Certificate Manager) un certificato per notifichedigitali.it 
+  con validazione DNS.
+- Chiedere al dipartimento di Engineering la creazione del DNS necessario alla validazione 
+  del certificato. 
+- Aspettare che ACM validi il certificato
+- Copiare l'ARN del certificato servità successivamente.
+
+# Installazione stack
+1. Verificare che dall'account AWS designato sia utilizzabile una VPC con 
+  - almeno tre subnet che possano essere raggiunte da internet;
+  - un internet gateway
+  Se tale VPC non è presente occorre crearla con un template funzionalmente 
+  equivalente a minimal-vpc.yaml. 
+
+2. Fare il deploy da console AWS CloudFormation del template global-accelerator-redirect.yaml
+  - Nome dello stack: _landing-static-ip_
+  - Parametro "CertificateArn": incollare l'ARN del certificato creato in precedenza
+  - Parametro "ClientAffinity": lasciare default (_NONE_)
+  - Parametro "DNSHostname": il valore del dominio a cui vengono ridirezionate le chiamate. In produzione 
+    sarà _www.notifichedigitali.it_
+  - Parametro "GlobalAccName": _static-ip-landing-&lt;EnvName&gt;_ dove &lt;EnvName&gt; è uno tra dev, svil, 
+    coll, cert, prod
+  - Parametro "IpAddressType": lasciare il default (_ipv4_)
+  - Parametro "Subnets": lista separata da virgole degli id delle 3 sottoreti richieste al punto 1.
+  - Parametro "VpcId": id della VPC richieste al punto 1.
+
+3. Copiare l'output "AcceleratorIPAddresses".
+
+
+# Configurazione Entry DNS
+- Comunicare al dipartimento di Engineering gli indiriziz IP statici per definire l'entry DNS di tipo A
+  per il dominio _notifichedigitali.it_
+
+
+

--- a/scripts/global-redirect/README.md
+++ b/scripts/global-redirect/README.md
@@ -24,7 +24,7 @@ __N.B.__: da definire in che Account AWS avverrà il deploy della soluzione.
   - Parametro "DNSHostname": il valore del dominio a cui vengono ridirezionate le chiamate. In produzione 
     sarà _www.notifichedigitali.it_
   - Parametro "GlobalAccName": _static-ip-landing-&lt;EnvName&gt;_ dove &lt;EnvName&gt; è uno tra dev, svil, 
-    coll, cert, prod
+    coll, cert, hotifx, prod
   - Parametro "IpAddressType": lasciare il default (_ipv4_)
   - Parametro "Subnets": lista separata da virgole degli id delle 3 sottoreti richieste al punto 1.
   - Parametro "VpcId": id della VPC richieste al punto 1.

--- a/scripts/global-redirect/README.md
+++ b/scripts/global-redirect/README.md
@@ -25,7 +25,6 @@ __N.B.__: da definire in che Account AWS avverrà il deploy della soluzione.
     sarà _www.notifichedigitali.it_
   - Parametro "GlobalAccName": _static-ip-landing-&lt;EnvName&gt;_ dove &lt;EnvName&gt; è uno tra dev, svil, 
     coll, cert, hotifx, prod
-  - Parametro "IpAddressType": lasciare il default (_ipv4_)
   - Parametro "Subnets": lista separata da virgole degli id delle 3 sottoreti richieste al punto 1.
   - Parametro "VpcId": id della VPC richieste al punto 1.
 

--- a/scripts/global-redirect/cfn-templates/global-accelerator-redirect.yaml
+++ b/scripts/global-redirect/cfn-templates/global-accelerator-redirect.yaml
@@ -20,12 +20,6 @@ Parameters:
     Description: The hostname to redirect to.
     Type: String
   
-  IpAddressType:
-    AllowedValues: [ dualstack, ipv4 ]
-    Description: The IP address type.
-    Default: ipv4
-    Type: String
-
   Subnets:
     Description: The IDs of the subnets.
     Type: List<AWS::EC2::Subnet::Id>
@@ -85,7 +79,7 @@ Resources:
   HttpALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties: 
-      IpAddressType: !Ref IpAddressType
+      IpAddressType: IPV4
       Name: !Sub ${GlobalAccName}-ALB
       Scheme: internal
       SecurityGroups: 

--- a/scripts/global-redirect/cfn-templates/global-accelerator-redirect.yaml
+++ b/scripts/global-redirect/cfn-templates/global-accelerator-redirect.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Creates a AWS Global Accelerator, associated with an Application Load Balancer to redirect HTTP to HTTPS
+Description: Creates a AWS Global Accelerator, associated with an Application Load Balancer to redirect HTTP and HTTPS traffic to another hostname in HTTPS.
 
 Parameters:
   CertificateArn:

--- a/scripts/global-redirect/cfn-templates/global-accelerator-redirect.yaml
+++ b/scripts/global-redirect/cfn-templates/global-accelerator-redirect.yaml
@@ -1,0 +1,160 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Creates a AWS Global Accelerator, associated with an Application Load Balancer to redirect HTTP to HTTPS
+
+Parameters:
+  CertificateArn:
+    Description: The ARN of the SSL certificate.
+    Type: String
+
+  ClientAffinity:
+    AllowedValues: [ NONE, SOURCE_IP ]
+    Description: Client affinity lets you direct all requests from a user to the same endpoint.
+    Type: String
+    Default: NONE
+
+  GlobalAccName:
+    Description: The name of the accelerator.
+    Type: String
+
+  DNSHostname:
+    Description: The hostname to redirect to.
+    Type: String
+  
+  IpAddressType:
+    AllowedValues: [ dualstack, ipv4 ]
+    Description: The IP address type.
+    Default: ipv4
+    Type: String
+
+  Subnets:
+    Description: The IDs of the subnets.
+    Type: List<AWS::EC2::Subnet::Id>
+
+  VpcId:
+    Description: The ID of the VPC for the security group.
+    Type: AWS::EC2::VPC::Id
+
+Resources:
+  Accelerator:
+    Type: AWS::GlobalAccelerator::Accelerator
+    Properties: 
+      Enabled: true
+      IpAddressType: IPV4
+      Name: !Ref GlobalAccName
+
+  HttpGlobalAccListener:
+    Type: AWS::GlobalAccelerator::Listener
+    Properties: 
+      AcceleratorArn: !Ref Accelerator
+      ClientAffinity: !Ref ClientAffinity
+      PortRanges: 
+        - FromPort: 80
+          ToPort: 80
+      Protocol: TCP
+
+  HttpsGlobalAccListener:
+    Type: AWS::GlobalAccelerator::Listener
+    Properties: 
+      AcceleratorArn: !Ref Accelerator
+      ClientAffinity: !Ref ClientAffinity
+      PortRanges: 
+        - FromPort: 443
+          ToPort: 443
+      Protocol: TCP
+
+  HttpEndpointGroup:
+    Type: AWS::GlobalAccelerator::EndpointGroup
+    Properties: 
+      EndpointConfigurations: 
+        - ClientIPPreservationEnabled: true
+          EndpointId: !Ref HttpALB
+      EndpointGroupRegion: !Ref AWS::Region
+      ListenerArn: !Ref HttpGlobalAccListener
+      TrafficDialPercentage: 100
+
+  HttpsEndpointGroup:
+    Type: AWS::GlobalAccelerator::EndpointGroup
+    Properties: 
+      EndpointConfigurations: 
+        - ClientIPPreservationEnabled: true
+          EndpointId: !Ref HttpALB
+      EndpointGroupRegion: !Ref AWS::Region
+      ListenerArn: !Ref HttpsGlobalAccListener
+      TrafficDialPercentage: 100
+
+  HttpALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties: 
+      IpAddressType: !Ref IpAddressType
+      Name: !Sub ${GlobalAccName}-ALB
+      Scheme: internal
+      SecurityGroups: 
+        - !Ref ALBSecurityGroup
+      Subnets: !Ref Subnets
+      Type: application
+
+  HttpALBListner:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties: 
+      DefaultActions: 
+        - Type: redirect
+          RedirectConfig: 
+            Host: !Ref DNSHostname
+            Path: "/#{path}"
+            Port: 443
+            Protocol: HTTPS
+            Query: "#{query}"
+            StatusCode: HTTP_301
+      LoadBalancerArn: !Ref HttpALB
+      Port: 80
+      Protocol: HTTP
+
+  HttpsALBListner:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties: 
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      DefaultActions: 
+        - Type: redirect
+          RedirectConfig: 
+            Host: !Ref DNSHostname
+            Path: "/#{path}"
+            Port: 443
+            Protocol: HTTPS
+            Query: "#{query}"
+            StatusCode: HTTP_301
+      LoadBalancerArn: !Ref HttpALB
+      Port: 443
+      Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-2016-08
+
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties: 
+      GroupDescription: !Sub  "Security group for ${GlobalAccName}-ALB"
+      GroupName: !Sub ${GlobalAccName}-ALB
+      SecurityGroupEgress: 
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic
+          IpProtocol: -1
+      SecurityGroupIngress: 
+        - CidrIp: 0.0.0.0/0
+          Description: Allow HTTP requests
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+        - CidrIp: 0.0.0.0/0
+          Description: Allow HTTPS requests
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+      Tags: 
+        - Key: Name
+          Value: !Sub ${GlobalAccName}-ALB
+      VpcId: !Ref VpcId
+
+Outputs:
+  AcceleratorIPAddresses:
+    Description: Array of IPv4 addresses in the IP address set.
+    Value: !Join [", ", !GetAtt Accelerator.Ipv4Addresses]
+

--- a/scripts/global-redirect/cfn-templates/minimal-vpc.yaml
+++ b/scripts/global-redirect/cfn-templates/minimal-vpc.yaml
@@ -1,0 +1,140 @@
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Define a VPC with 3 public subnet
+
+Parameters:
+
+  ## Ingress VPC
+  VpcIngressName:
+    Type: String
+    Description: 'Ingress VPC name'
+    Default: landing-static-ip-vpc
+  VpcIngressNumber:
+    Type: String
+    Description: Second byte from the left for VPC CIDR
+    Default: 240
+
+Resources:
+
+  ###                        INGRESS VPC DEFINITION                        ###
+  ############################################################################
+
+  ## VPC for Ingress 
+  IngressVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Join ['', ["10.", !Ref "VpcIngressNumber", ".0.0/16" ]]
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: !Sub ${VpcIngressName}-VPC
+  
+  ## Internet Gateway ...
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub ${VpcIngressName}-IG
+  
+  ## ... and its attachment
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref IngressVPC
+
+  ## Subnet 1 - Public
+  IngressVPCPublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: !Join ['', ["10.", !Ref "VpcIngressNumber", ".1.0/24" ]]
+      VpcId:
+        Ref: IngressVPC
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs: ""
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: Ingress VPC - PublicSubnet1
+
+  ## Subnet 2 - Public
+  IngressVPCPublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: !Join ['', ["10.", !Ref "VpcIngressNumber", ".2.0/24" ]]
+      VpcId:
+        Ref: IngressVPC
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs: ""
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: Ingress VPC - PublicSubnet2
+
+  ## Subnet 3 - Public
+  IngressVPCPublicSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: !Join ['', ["10.", !Ref "VpcIngressNumber", ".0.0/24" ]]
+      VpcId:
+        Ref: IngressVPC
+      AvailabilityZone:
+        Fn::Select:
+          - 2
+          - Fn::GetAZs: ""
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: Ingress VPC - PublicSubnet3
+
+
+  ## Routing
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref IngressVPC
+      Tags:
+        - Key: Name
+          Value: !Sub ${VpcIngressName} Public Routes
+
+  DefaultPublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref IngressVPCPublicSubnet1
+
+  PublicSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref IngressVPCPublicSubnet2
+
+  PublicSubnet3RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref IngressVPCPublicSubnet3
+
+Outputs:
+  VPC:
+    Description: A reference to the created VPC
+    Value: !Ref IngressVPC
+
+  PublicSubnets:
+    Description: A list of the public subnets
+    Value: !Join [ ",", [ !Ref IngressVPCPublicSubnet1, !Ref IngressVPCPublicSubnet2, !Ref IngressVPCPublicSubnet3 ]]

--- a/scripts/global-redirect/cfn-templates/minimal-vpc.yaml
+++ b/scripts/global-redirect/cfn-templates/minimal-vpc.yaml
@@ -82,7 +82,7 @@ Resources:
   IngressVPCPublicSubnet3:
     Type: AWS::EC2::Subnet
     Properties:
-      CidrBlock: !Join ['', ["10.", !Ref "VpcIngressNumber", ".0.0/24" ]]
+      CidrBlock: !Join ['', ["10.", !Ref "VpcIngressNumber", ".3.0/24" ]]
       VpcId:
         Ref: IngressVPC
       AvailabilityZone:


### PR DESCRIPTION
Meccanismo per la gestione del redirect di notifichedigitali.it a www.notifichedigitali.it

Per ulteriori dettagli vedere il README.md allegato

Per il testing di suggerisce di 
- usare l'account di dev nella zona di parigi perché c'è già un certificato creato per test (creato per il dominio static-ip-entry.dev.pn.pagopa.it).
- per la creazione dell'entry DNS non chiedere ad engineering ma limitarsi a usare la console di route 53 e aggiungere il record alla zona "dev.pn.pagopa.it" gestita dallo stesso account

