### PR TITLE
PN-2825: stack_trace truncation

### DIFF
--- a/runtime-infra/lambdas/opensearch-delivery/lib/openSearch.js
+++ b/runtime-infra/lambdas/opensearch-delivery/lib/openSearch.js
@@ -67,6 +67,11 @@ function prepareBulkBody(logs){
                     jsonMessage.kinesisSeqNumber = doc.kinesisSeqNumber
                     jsonMessage.logGroup = doc.logGroup
                     jsonMessage.logStream = doc.logStream
+
+                    if(jsonMessage.stack_trace) {
+                      jsonMessage.stack_trace = truncateMessage(jsonMessage.stack_trace, 20000)
+                    }
+                    
                     formattedLogs.push(jsonMessage);
                 }
             } catch(e){


### PR DESCRIPTION
Truncated `stack_trace` at 20K chars.