### PR TITLE
Feature/pn 2658

### DIFF
--- a/runtime-infra/fragments/sqs-queue.yaml
+++ b/runtime-infra/fragments/sqs-queue.yaml
@@ -214,7 +214,7 @@ Resources:
       AlarmName: !Sub "${QueueName}-DLQ-HasOldMessage"
       AlarmDescription: "Alarm dla messages when the oldest message in dlq queue is older than limit QueueOldestAgeLimit"
       Namespace: "AWS/SQS"
-      MetricName: "ApproximateNumberOfMessagesVisible"
+      MetricName: "ApproximateAgeOfOldestMessage"
       Dimensions:
         - Name: "QueueName"
           Value: !If [ IsNotFifo, !Sub '${DeadLetterQueue.QueueName}', !Sub '${DeadLetterQueueFifo.QueueName}' ]

--- a/runtime-infra/fragments/sqs-queue.yaml
+++ b/runtime-infra/fragments/sqs-queue.yaml
@@ -53,6 +53,10 @@ Parameters:
     Type: String
     Default: 'false'
     Description: 'For this queue, set if there is an alarm to create'
+  QueueOldestAgeLimit:
+    Type: Number
+    Default: '21600'
+    Description: 'Oldest job age (in seconds) before raising an alarm'
 
 Conditions:
   DlqHasDefaultName: !Equals [ !Ref DeadLetterQueueName, '-' ]
@@ -179,6 +183,53 @@ Resources:
       OKActions:
         - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
 
+  QueueHasOldMessagesAlarm:
+    Condition: IsWithAlarm
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${QueueName}-HasOldMessage"
+      AlarmDescription: "Alarm messages when the oldest message in queue is older than limit QueueOldestAgeLimit"
+      Namespace: "AWS/SQS"
+      MetricName: "ApproximateAgeOfOldestMessage"
+      TreatMissingData: "notBreaching"
+      Dimensions:
+        - Name: "QueueName"
+          Value: !If [ IsNotFifo, !Sub '${Queue.QueueName}', !Sub '${QueueFifo.QueueName}' ]
+      Statistic: "Maximum"
+      Period: 60  
+      Threshold: !Ref QueueOldestAgeLimit
+      ComparisonOperator: "GreaterThanOrEqualToThreshold" 
+      EvaluationPeriods: 1       
+      AlarmActions:
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
+      InsufficientDataActions:
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
+      OKActions:
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
+
+  DLQHasOldMessagesAlarm:
+    Condition: IsDLQHasMessagesAlarm
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${QueueName}-DLQ-HasOldMessage"
+      AlarmDescription: "Alarm dla messages when the oldest message in dlq queue is older than limit QueueOldestAgeLimit"
+      Namespace: "AWS/SQS"
+      MetricName: "ApproximateNumberOfMessagesVisible"
+      Dimensions:
+        - Name: "QueueName"
+          Value: !If [ IsNotFifo, !Sub '${DeadLetterQueue.QueueName}', !Sub '${DeadLetterQueueFifo.QueueName}' ]
+      Statistic: "Maximum"
+      Period: 60  
+      Threshold: !Ref QueueOldestAgeLimit
+      TreatMissingData: "notBreaching"
+      ComparisonOperator: "GreaterThanOrEqualToThreshold" 
+      EvaluationPeriods: 1       
+      AlarmActions:
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
+      InsufficientDataActions:
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
+      OKActions:
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
 
 Outputs:
   # Queue info
@@ -212,4 +263,15 @@ Outputs:
       - !If
         - IsWithAlarm
         - !GetAtt QueueHasMessagesAlarm.Arn
+        - ''
+
+  SqsAgeAlarmArn:
+    Description: ARN of the SQS Age alarm
+    Value:
+      !If
+      - IsDLQHasMessagesAlarm
+      - !GetAtt DLQHasOldMessagesAlarm.Arn
+      - !If
+        - IsWithAlarm
+        - !GetAtt QueueHasOldMessagesAlarm.Arn
         - ''

--- a/runtime-infra/fragments/sqs-queue.yaml
+++ b/runtime-infra/fragments/sqs-queue.yaml
@@ -184,7 +184,7 @@ Resources:
         - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
 
   QueueHasOldMessagesAlarm:
-    Condition: IsWithAlarm
+    Condition: IsWithDLQ
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${QueueName}-HasOldMessage"
@@ -206,31 +206,7 @@ Resources:
         - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
       OKActions:
         - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-
-  DLQHasOldMessagesAlarm:
-    Condition: IsDLQHasMessagesAlarm
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub "${QueueName}-DLQ-HasOldMessage"
-      AlarmDescription: "Alarm dla messages when the oldest message in dlq queue is older than limit QueueOldestAgeLimit"
-      Namespace: "AWS/SQS"
-      MetricName: "ApproximateAgeOfOldestMessage"
-      Dimensions:
-        - Name: "QueueName"
-          Value: !If [ IsNotFifo, !Sub '${DeadLetterQueue.QueueName}', !Sub '${DeadLetterQueueFifo.QueueName}' ]
-      Statistic: "Maximum"
-      Period: 60  
-      Threshold: !Ref QueueOldestAgeLimit
-      TreatMissingData: "notBreaching"
-      ComparisonOperator: "GreaterThanOrEqualToThreshold" 
-      EvaluationPeriods: 1       
-      AlarmActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-      InsufficientDataActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-      OKActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AlarmSNSTopicName}'
-
+  
 Outputs:
   # Queue info
   QueueName:
@@ -269,9 +245,6 @@ Outputs:
     Description: ARN of the SQS Age alarm
     Value:
       !If
-      - IsDLQHasMessagesAlarm
-      - !GetAtt DLQHasOldMessagesAlarm.Arn
-      - !If
-        - IsWithAlarm
-        - !GetAtt QueueHasOldMessagesAlarm.Arn
-        - ''
+      - IsWithDLQ
+      - !GetAtt QueueHasOldMessagesAlarm.Arn
+      - ''

--- a/runtime-infra/pn-ipc.yaml
+++ b/runtime-infra/pn-ipc.yaml
@@ -481,6 +481,9 @@ Outputs:
   SafeStorageToDeliveryPushQueueAlarmARN:
     Value: !GetAtt SafeStorageToDeliveryPushQueue.Outputs.SqsDLQAlarmArn
     Description: SafeStorage-to-delivery-push queue alarm ARN
+  SafeStorageToDeliveryPushQueueAgeAlarmARN:
+    Value: !GetAtt SafeStorageToDeliveryPushQueue.Outputs.SqsAgeAlarmArn
+    Description: SafeStorage-to-delivery-push queue age alarm ARN
 
   # Delivery push inputs
   DeliveryPushInputsQueueName:
@@ -495,6 +498,9 @@ Outputs:
   DeliveryPushInputsQueueAlarmARN:
     Value: !GetAtt DeliveryPushInputsQueue.Outputs.SqsDLQAlarmArn
     Description: pn-delivery-push input queue alarm ARN
+  DeliveryPushInputsQueueAgeAlarmARN:
+    Value: !GetAtt DeliveryPushInputsQueue.Outputs.SqsAgeAlarmArn
+    Description: pn-delivery-push input queue age alarm ARN
 
   # External channels inputs
   ExternalChannelsInputsQueueName:
@@ -509,6 +515,9 @@ Outputs:
   ExternalChannelsInputsQueueAlarmARN:
     Value: !GetAtt ExternalChannelsInputsQueue.Outputs.SqsDLQAlarmArn
     Description: pn-external-channels input queue alarm ARN
+  ExternalChannelsInputsQueueAgeAlarmARN:
+    Value: !GetAtt ExternalChannelsInputsQueue.Outputs.SqsAgeAlarmArn
+    Description: pn-external-channels input queue age alarm ARN
 
   # External channels outputs
   ExternalChannelsOutputsQueueName:
@@ -523,6 +532,9 @@ Outputs:
   ExternalChannelsOutputsQueueAlarmARN:
     Value: !GetAtt ExternalChannelsOutputsQueue.Outputs.SqsDLQAlarmArn
     Description: pn-external-channels output queue alarm ARN
+  ExternalChannelsOutputsQueueAgeAlarmARN:
+    Value: !GetAtt ExternalChannelsOutputsQueue.Outputs.SqsAgeAlarmArn
+    Description: pn-external-channels output queue age alarm ARN
 
   # External channels to user attribute outputs
   ExternalChannels2UserAttributesQueueName:
@@ -537,6 +549,9 @@ Outputs:
   ExternalChannels2UserAttributesQueueAlarmARN:
     Value: !GetAtt ExternalChannels2UserAttributesQueue.Outputs.SqsDLQAlarmArn
     Description: pn-external-channels output to user-attributes queue alarm ARN
+  ExternalChannels2UserAttributesQueueAgeAlarmARN:
+    Value: !GetAtt ExternalChannels2UserAttributesQueue.Outputs.SqsAgeAlarmArn
+    Description: pn-external-channels output to user-attributes queue age alarm ARN
 
   # External channels to pn-paper-channel
   ExternalChannels2PaperChannelQueueName:
@@ -551,6 +566,9 @@ Outputs:
   ExternalChannels2PaperChannelQueueAlarmARN:
     Value: !GetAtt ExternalChannels2PaperChannelQueue.Outputs.SqsDLQAlarmArn
     Description: pn-external-channels output to pn-paper-channel queue alarm ARN
+  ExternalChannels2PaperChannelQueueAgeAlarmARN:
+    Value: !GetAtt ExternalChannels2PaperChannelQueue.Outputs.SqsAgeAlarmArn
+    Description: pn-external-channels output to pn-paper-channel queue age alarm ARN
 
   # Downtime Logs composite alarm queue
   DowntimeLogsAggregateAlarmQueueName:
@@ -565,6 +583,9 @@ Outputs:
   DowntimeLogsAggregateAlarmQueueAlarmARN:
     Value: !GetAtt CompositeAlarmQueue.Outputs.SqsDLQAlarmArn
     Description: Aggregate alarm queue alarm ARN
+  DowntimeLogsAggregateAlarmQueueAgeAlarmARN:
+    Value: !GetAtt CompositeAlarmQueue.Outputs.SqsAgeAlarmArn
+    Description: Aggregate alarm queue age alarm ARN
   
   # Downtime Logs safe-storage events
   DowntimeLogsSafeStorageEventsQueueName:
@@ -579,6 +600,9 @@ Outputs:
   DowntimeLogsSafeStorageEventsQueueAlarmARN:
     Value: !GetAtt SafeStorageToDowntimeLogsQueue.Outputs.SqsDLQAlarmArn
     Description: Events form safe-storage to pn-downtime-logs queue alarm ARN
+  DowntimeLogsSafeStorageEventsQueueAgeAlarmARN:
+    Value: !GetAtt SafeStorageToDowntimeLogsQueue.Outputs.SqsAgeAlarmArn
+    Description: Events form safe-storage to pn-downtime-logs queue age alarm ARN
 
   # Kinesis Source Stream containing the DynamoDB Change Data Capture events
   CdcKinesisSourceStreamName:


### PR DESCRIPTION
Added alarm based on `ApproximateAgeOfOldestMessage` sqs metric.

Notes:
- the alarm is attached to the queue only, not to the DLQ, if any
- the threshold unit is seconds, the default value is 6 hours but can be overridden for each queue