### PR TITLE
fix Outputs member must evaluate to a String.

### DIFF
--- a/runtime-infra/fragments/api-gw-expose-service.yaml
+++ b/runtime-infra/fragments/api-gw-expose-service.yaml
@@ -185,7 +185,7 @@ Resources:
       ResourceId: !Ref PublicApiProxyResource
       HttpMethod: ANY
       ApiKeyRequired: !If [ UseApiKey, true, false]
-      AuthorizationType: !If [ IsPNPG, !Ref AWS::NoValue, CUSTOM]
+      AuthorizationType: !If [ IsPNPG, NONE, CUSTOM]
       AuthorizerId:
         Fn::If:
           - IsBackoffice

--- a/runtime-infra/fragments/api-gw-expose-service.yaml
+++ b/runtime-infra/fragments/api-gw-expose-service.yaml
@@ -511,7 +511,7 @@ Outputs:
             - !Ref IoAuthorizer
             - Fn::If:
                 - IsPNPG
-                - !Ref AWS::NoValue
+                - ""
                 - !Ref JwtAuthorizer
     Description: "Authorizer ARN"
 


### PR DESCRIPTION
FIX 
`Template format error: The Value field of every Outputs member must evaluate to a String.`