### PR TITLE
PN-13964: add object lock in s3 bucket logs

### DIFF
--- a/runtime-infra/pn-infra-storage-dev-cfg.json
+++ b/runtime-infra/pn-infra-storage-dev-cfg.json
@@ -5,7 +5,8 @@
       "LogsStreamRetentionHours": "48",
       "CdcStreamRetentionHours": "48",
       "BucketLogRetentionDays": "730",
-      "BucketCdcRetentionDays": "365"
+      "BucketCdcRetentionDays": "365",
+      "BucketObjectLockRetentionDays": "14"
     }
   }
   

--- a/runtime-infra/pn-infra-storage.yaml
+++ b/runtime-infra/pn-infra-storage.yaml
@@ -84,6 +84,11 @@ Parameters:
     Default: 'cdcTos3/'
     Description: Prefix for the cdc in the bucket
 
+  BucketObjectLockRetentionDays:
+    Type: Number
+    Default: 14
+    Description: Number of days of Default Retention ObjectLock
+
 Conditions:
   MakeBucketCondition: !Not [ !Equals [ !Ref BucketSuffix, '' ]]
   
@@ -124,7 +129,7 @@ Resources:
         Rule:
           DefaultRetention:
             Mode: GOVERNANCE
-            Days: 14
+            Days: !Ref BucketObjectLockRetentionDays
       # lifecycle configuration to delete objects after {BucketLogRetention} days
       LifecycleConfiguration:
         Rules:

--- a/runtime-infra/pn-infra-storage.yaml
+++ b/runtime-infra/pn-infra-storage.yaml
@@ -118,6 +118,13 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      ObjectLockEnabled: true 
+      ObjectLockConfiguration:
+        ObjectLockEnabled: Enabled
+        Rule:
+          DefaultRetention:
+            Mode: GOVERNANCE
+            Days: 14
       # lifecycle configuration to delete objects after {BucketLogRetention} days
       LifecycleConfiguration:
         Rules:


### PR DESCRIPTION
prima del merge assicurarsi che il backup sia stato creato correttamente e sia consistente 