### PR TITLE
feat(PN-15478): changed regex for GlueTableName in cdc-glue fragment, in or…

### DIFF
--- a/runtime-infra/fragments/cdc-glue.yaml
+++ b/runtime-infra/fragments/cdc-glue.yaml
@@ -17,7 +17,7 @@ Parameters:
     Description: Logs bucket name
   GlueTableName:
     Type: String
-    AllowedPattern: '^[a-z_]+$'
+    AllowedPattern: '^[a-z0-9_]+$'
     ConstraintDescription: |
        Glue table name for data-quality-<env>-cfg.json file,
        accept only lowercase letters and underscores.


### PR DESCRIPTION
…der to allow numbers char in the table name