### PR TITLE
fix(PN-19730): add OneIdentity CDN to pn-frontend CSP

### DIFF
--- a/runtime-infra/frontend/pn-frontend/aws-cdn-templates/one-cdn.yaml
+++ b/runtime-infra/frontend/pn-frontend/aws-cdn-templates/one-cdn.yaml
@@ -691,7 +691,7 @@ Resources:
                     worker-src 'none'; \
                     font-src 'self'; \
                     frame-ancestors 'none' ; \
-                    img-src 'self' https://assets.cdn.io.italia.it/ https://selcucheckoutsa.z6.web.core.windows.net/ https://selfcare.pagopa.it/ https://selcuweupnpgcheckoutsa.z6.web.core.windows.net/ https://pnpg.selfcare.pagopa.it/ data:"
+                    img-src 'self' https://assets.cdn.io.italia.it/ https://selcucheckoutsa.z6.web.core.windows.net/ https://selfcare.pagopa.it/ https://selcuweupnpgcheckoutsa.z6.web.core.windows.net/ https://pnpg.selfcare.pagopa.it/ https://assets.oneid.pagopa.it/assets/idps https://assets.uat.oneid.pagopa.it/assets/idps data:"
             Override: true
           # add_header X-Content-Type-Options "nosniff";
           ContentTypeOptions:

--- a/runtime-infra/frontend/pn-frontend/aws-cdn-templates/one-cdn.yaml
+++ b/runtime-infra/frontend/pn-frontend/aws-cdn-templates/one-cdn.yaml
@@ -686,6 +686,8 @@ Resources:
                     https://selfcare.pagopa.it/assets/ \
                     https://privacyportalde-cdn.onetrust.com/ \
                     https://privacyportal-de.onetrust.com/ \
+                    https://uat.oneid.pagopa.it/idps \
+                    https://oneid.pagopa.it/idps \
                     ${WebApiUrl}; \
                     style-src 'self' 'unsafe-inline' https://privacyportalde-cdn.onetrust.com/; \
                     worker-src 'none'; \


### PR DESCRIPTION
## Description

Add the OneIdentity CDN (both UAT and PROD) to the pn-frontend CSP to allow fetching of IDP logos.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes