### PR TITLE
fix(PN-19730): add trailing slash to OneIdentity CDN url

### DIFF
--- a/runtime-infra/frontend/pn-frontend/aws-cdn-templates/one-cdn.yaml
+++ b/runtime-infra/frontend/pn-frontend/aws-cdn-templates/one-cdn.yaml
@@ -693,7 +693,7 @@ Resources:
                     worker-src 'none'; \
                     font-src 'self'; \
                     frame-ancestors 'none' ; \
-                    img-src 'self' https://assets.cdn.io.italia.it/ https://selcucheckoutsa.z6.web.core.windows.net/ https://selfcare.pagopa.it/ https://selcuweupnpgcheckoutsa.z6.web.core.windows.net/ https://pnpg.selfcare.pagopa.it/ https://assets.oneid.pagopa.it/assets/idps https://assets.uat.oneid.pagopa.it/assets/idps data:"
+                    img-src 'self' https://assets.cdn.io.italia.it/ https://selcucheckoutsa.z6.web.core.windows.net/ https://selfcare.pagopa.it/ https://selcuweupnpgcheckoutsa.z6.web.core.windows.net/ https://pnpg.selfcare.pagopa.it/ https://assets.oneid.pagopa.it/assets/idps/ https://assets.uat.oneid.pagopa.it/assets/idps/ data:"
             Override: true
           # add_header X-Content-Type-Options "nosniff";
           ContentTypeOptions:


### PR DESCRIPTION
## Description

Add trailing slash to OneIdentity CDN url

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes