### PR TITLE
Changes made

### DIFF
--- a/runtime-infra/fragments/ecs-service.yaml
+++ b/runtime-infra/fragments/ecs-service.yaml
@@ -141,6 +141,11 @@ Parameters:
     Type: String
     Default: '/'
 
+  ContainerStopTimeout:
+    Description: Seconds to wait after SIGTERM before forcing container stop. Should be >= target group deregistration delay.
+    Type: Number
+    Default: 90
+
   # Autoscaling parameters
   AutoscalingStrategy:
     Description: Autoscaling strategy.
@@ -1143,6 +1148,7 @@ Resources:
       ContainerDefinitions:
         - Name: !Sub '${MicroServiceUniqueName}'
           Image: !Ref ContainerImageURI
+          StopTimeout: !Ref ContainerStopTimeout
           Memory: 
             'Fn::If':
               - HasOtelXRayDisable


### PR DESCRIPTION
- Added new parameter ContainerStopTimeout (default 90 seconds) in ecs-service.yaml:144-147
- Wired it into the main app container as StopTimeout in ecs-service.yaml:1151

Why this helps
This keeps the task alive longer after SIGTERM, giving ALB target deregistration (deregistration_delay.timeout_seconds = 60) time to drain in-flight traffic before force-stop. Current ALB deregistration setting is in ecs-service.yaml:1997-1998.

## Description

<!-- Describe your changes in detail -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes